### PR TITLE
fix import from collections to work on python3

### DIFF
--- a/src/redfish/ris/utils.py
+++ b/src/redfish/ris/utils.py
@@ -25,7 +25,9 @@ import logging
 if six.PY3:
     from functools import reduce
 
-from collections import Mapping
+if six.PY2:
+    from collections import Mapping
+from collections.abc import Mapping
 
 import jsonpath_rw
 


### PR DESCRIPTION
When running on Python 3.10 file Utils.py Line 28 -> 'from collections import Mapping' raises exception as collections modules has been changed from python 2 to python 3. Changes tested to work on both python2 and python 3



-----Synopsis of Commits Above-----

**Please fill out the following when submitting the PR**

## Status
- [ *] READY 

## Additional High Level Description
A few sentences describing the overall goals of the pull request's commits.
- Include the issue number here if it fixes one. Example `#1`
- Include the QUIX number here if it fixes one.

## Dependent PRs
none

## Before Status can be set to READY I have completed the following:
- [ *] Check if documentation updates
- [ *] Check if example code updates
- [ *] Pylint static analysis tests are passing above 9.0/10.0
- [ ] Unit tests added for any new functions/features and passed.
- [ *] Targeted/Custom Testing performed. Indicate the results in the description above or as additional comments.
